### PR TITLE
Patch w/ Etag

### DIFF
--- a/src/com/scottyplunkett/server/HTTPRequest.java
+++ b/src/com/scottyplunkett/server/HTTPRequest.java
@@ -3,25 +3,52 @@ package com.scottyplunkett.server;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 
 class HTTPRequest {
     private ArrayList<String> requestContent;
     private String requestLine;
+    private String eTag;
+    private String body;
 
     HTTPRequest(BufferedReader in) throws IOException {
         requestContent = new ArrayList<>();
-        String s;
-        while ((s = in.readLine()) != null) {
-            requestContent.add(s);
-            if (s.isEmpty()) {
+        StringBuilder fullRequest = new StringBuilder();
+        int nextChar;
+        while ((nextChar = in.read()) != -1) {
+            fullRequest.append((char)nextChar);
+            if (!in.ready()) {
                 break;
             }
         }
+        Collections.addAll(requestContent, fullRequest.toString().split("\r\n"));
         requestLine = requestContent.get(0);
+        setEtag();
+        setBody();
+    }
+
+    private void setEtag() {
+        String secondLineHeader = requestContent.get(1).split("\\s")[0];
+        if ("If-Match:".equals(secondLineHeader) || "If-None-Match:".equals(secondLineHeader)) {
+            eTag = requestContent.get(1).split("\\s")[1];
+        }
+    }
+
+    private void setBody() {
+        int index = requestContent.size() - 1;
+        body = requestContent.get(index);
     }
 
     String getRequestLine() {
         return requestLine;
+    }
+
+    String getEtag() {
+        return eTag;
+    }
+
+    String getBody() {
+        return body;
     }
 }
 

--- a/src/com/scottyplunkett/server/HTTPResponse.java
+++ b/src/com/scottyplunkett/server/HTTPResponse.java
@@ -3,19 +3,26 @@ package com.scottyplunkett.server;
 import java.io.IOException;
 
 class HTTPResponse {
+    private HTTPRequest request;
     private String responseContent;
 
-    HTTPResponse(String requested) throws IOException {
-        this(requested, Date.getDate());
+    HTTPResponse(HTTPRequest request) throws IOException {
+        this(request, Date.getDate());
     }
 
-    HTTPResponse(String requested, String date) throws IOException {
-        String route = Parser.findRequestedRoute(requested);
-        int encoded = HTTPResponseCode.encode(route);
-        String responseCode = HTTPResponseCode.retrieve(encoded);
-        HTTPResponseHeaders responseHeaders = setHeaders(requested, date, responseCode);
-        HTTPResponseBody responseBody = new HTTPResponseBody(requested);
-        responseContent = responseHeaders.get() + "\r\n" + responseBody.get();
+    HTTPResponse(HTTPRequest request, String date) throws IOException {
+        String requestLine = request.getRequestLine();
+        if("/patch-content.txt".equals(requestLine.split("\\s")[1])) {
+          PatchContentResponse patchContentResponse = new PatchContentResponse(request, date);
+          responseContent = patchContentResponse.get();
+        } else {
+            String route = Parser.findRequestedRoute(requestLine);
+            int encoded = HTTPResponseCode.encode(route);
+            String responseCode = HTTPResponseCode.retrieve(encoded);
+            HTTPResponseHeaders responseHeaders = setHeaders(requestLine, date, responseCode);
+            HTTPResponseBody responseBody = new HTTPResponseBody(requestLine);
+            responseContent = responseHeaders.get() + "\r\n" + responseBody.get();
+        }
     }
 
     private HTTPResponseHeaders setHeaders(String requested, String date, String responseCode) {
@@ -32,4 +39,5 @@ class HTTPResponse {
     String get() {
         return responseContent;
     }
+
 }

--- a/src/com/scottyplunkett/server/HTTPServer.java
+++ b/src/com/scottyplunkett/server/HTTPServer.java
@@ -37,8 +37,7 @@ class HTTPServer {
                               BufferedReader in,
                               BufferedWriter out) throws IOException {
         HTTPRequest request = new HTTPRequest(in);
-        String resourceRequested = request.getRequestLine();
-        String response = new HTTPResponse(resourceRequested).get();
+        String response = new HTTPResponse(request).get();
         out.write(response);
         out.flush();
         System.err.println("Client served…");

--- a/src/com/scottyplunkett/server/PatchContentResponse.java
+++ b/src/com/scottyplunkett/server/PatchContentResponse.java
@@ -1,0 +1,41 @@
+package com.scottyplunkett.server;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class PatchContentResponse {
+    private String responseContent;
+    private String headers;
+    private String body;
+
+    private String patchTag = "dc50a0d27dda2eee9f65644cd7e4c9cf11de8bec";
+    private String defaultTag = "5c36acad75b78b82be6d9cbbd6143ab7e0cc04b0";
+    private final byte[] defaultBytes = "default content".getBytes();
+    private final byte[] patchBytes = "patched content".getBytes();
+    private final Path path = Paths.get("public/patch-content.txt");
+
+    PatchContentResponse(HTTPRequest request, String date) throws IOException {
+        String requestLine = request.getRequestLine();
+        String requestMethod = requestLine.split("\\s")[0];
+        if("PATCH".equals(requestMethod)) {
+            headers = "HTTP/1.1 204\r\nDate: " + date + "\r\nContent-Type: text/html\r\n";
+            body = "";
+            writeToFile(request.getEtag());
+        } else {
+            headers = "HTTP/1.1 200 OK\r\nDate: " + date + "\r\nContent-Type: text/html\r\n";
+            body = new HTTPResponseBody(request.getRequestLine()).get();
+        }
+        responseContent = headers + "\r\n" + body;
+    }
+
+    String get() {
+        return responseContent;
+    }
+
+    private void writeToFile(String eTag) throws IOException {
+        byte[] contentBytes = eTag.equals(patchTag) ? patchBytes : defaultBytes;
+        Files.write(path, contentBytes);
+    }
+}

--- a/src/com/scottyplunkett/server/Router.java
+++ b/src/com/scottyplunkett/server/Router.java
@@ -16,6 +16,8 @@ class Router {
             case "GET /josh HTTP/1.1" : return Paths.get("pages/josh.html");
             case "GET /file1 HTTP/1.1" : return Paths.get("pages/file1");
             case "GET /coffee HTTP/1.1" : return Paths.get("pages/418.html");
+            case "GET /patch-content.txt HTTP/1.1" : return Paths.get("public/patch-content.txt");
+            case "PATCH /patch-content.txt HTTP/1.1" : return Paths.get("public/patch-content.txt");
             case "OPTIONS /method_options HTTP/1.1" : return Paths.get("pages/method_options.html");
             case "OPTIONS /method_options2 HTTP/1.1" : return Paths.get("pages/method_options.html");
             default : return Paths.get("pages/404.html");

--- a/test/com/scottyplunkett/server/HTTPResponseTest.java
+++ b/test/com/scottyplunkett/server/HTTPResponseTest.java
@@ -2,7 +2,7 @@ package com.scottyplunkett.server;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
@@ -13,45 +13,87 @@ class HTTPResponseTest {
 
     @Test
     void get() throws IOException {
+        String nicoleRequest = "GET /nicole HTTP/1.1\r\nline2\r\nline3\r\n";
+        InputStream stream = new ByteArrayInputStream(nicoleRequest.getBytes());
+        InputStreamReader feed = new InputStreamReader(stream);
+        BufferedReader in = new BufferedReader(feed);
+        HTTPRequest request = new HTTPRequest(in);
+
         String expectedHeaders = "HTTP/1.1 200 OK\r\n" +
                                  "Date: bla\r\n" +
                                  "Content-Type: text/html\r\n";
-        String nicoleRequest = "GET /nicole HTTP/1.1";
-        Path filePath = Router.route(nicoleRequest);
+        Path filePath = Router.route(request.getRequestLine());
         String content = Files.lines( filePath ).collect( Collectors.joining() );
-        assertEquals(expectedHeaders + "\r\n" + content, new HTTPResponse(nicoleRequest, "bla").get());
+        assertEquals(expectedHeaders + "\r\n" + content, new HTTPResponse(request, "bla").get());
     }
 
     @Test
     void getResponseToRequestWithParams() throws IOException {
+        String requestedWithParams =
+                "GET /pages?variable_1=Scott&variable_2=Plunkett HTTP/1.1\r\nline2\nline3\n";
+        InputStream stream = new ByteArrayInputStream(requestedWithParams.getBytes());
+        InputStreamReader feed = new InputStreamReader(stream);
+        BufferedReader in = new BufferedReader(feed);
+        HTTPRequest request = new HTTPRequest(in);
+
         String expectedGeneratedContent = "<p>variable_1 = Scott</p><br><p>variable_2 = Plunkett</p><br>";
         String expectedHeaders = "HTTP/1.1 200 OK\r\n" +
                                  "Date: bla\r\n" +
                                  "Content-Type: text/html\r\n";
-        String requestedWithParams = "GET /pages?variable_1=Scott&variable_2=Plunkett HTTP/1.1";
+
         Path templatePath = Router.route(requestedWithParams);
         String content = Files.lines( templatePath ).collect( Collectors.joining() );
         content = content.replace("$content", expectedGeneratedContent);
-        assertEquals(expectedHeaders + "\r\n" + content, new HTTPResponse(requestedWithParams, "bla").get());
+        assertEquals(expectedHeaders + "\r\n" + content, new HTTPResponse(request, "bla").get());
     }
 
     @Test
     void getResponseToOptionsRequestForMethodOptions() throws IOException {
+        String requestMethodOptions = "OPTIONS /method_options HTTP/1.1\r\nline2\nline3\n";
+        InputStream stream = new ByteArrayInputStream(requestMethodOptions.getBytes());
+        InputStreamReader feed = new InputStreamReader(stream);
+        BufferedReader in = new BufferedReader(feed);
+        HTTPRequest request = new HTTPRequest(in);
+
         String expectedHeaders = "HTTP/1.1 200 OK\r\n" +
                                  "Allow: GET,HEAD,POST,OPTIONS,PUT\r\n" +
                                  "Date: bla\r\n" +
                                  "Content-Type: text/html\r\n";
-        String requestMethodOptions = "OPTIONS /method_options HTTP/1.1";
-        assertEquals(expectedHeaders + "\r\n" + "", new HTTPResponse(requestMethodOptions, "bla").get());
+
+        assertEquals(expectedHeaders + "\r\n" + "", new HTTPResponse(request, "bla").get());
     }
 
     @Test
     void getResponseToOptionsRequestForMethodOptions2() throws IOException {
-        String expectedHeaders = "HTTP/1.1 200 OK\r\n" +
-                                 "Allow: GET,OPTIONS\r\n" +
-                                 "Date: bla\r\n" +
-                                 "Content-Type: text/html\r\n";
-        String requestMethodOptions2 = "OPTIONS /method_options2 HTTP/1.1";
-        assertEquals(expectedHeaders + "\r\n" + "", new HTTPResponse(requestMethodOptions2, "bla").get());
+        String requestMethodOptions2 = "OPTIONS /method_options2 HTTP/1.1\r\nline2\nline3\n";
+        InputStream stream = new ByteArrayInputStream(requestMethodOptions2.getBytes());
+        InputStreamReader feed = new InputStreamReader(stream);
+        BufferedReader in = new BufferedReader(feed);
+        HTTPRequest request = new HTTPRequest(in);
+        String expectedHeaders = "HTTP/1.1 200 OK\r\nAllow: GET,OPTIONS\r\nDate: bla\r\nContent-Type: text/html\r\n";
+        assertEquals(expectedHeaders + "\r\n" + "", new HTTPResponse(request, "bla").get());
+    }
+
+    @Test
+    void getResponseToGetRequestForPatchContent() throws IOException {
+        String requestGetPatchContent = "GET /patch-content.txt HTTP/1.1\r\nline2\nline3\n";
+        InputStream stream = new ByteArrayInputStream(requestGetPatchContent.getBytes());
+        InputStreamReader feed = new InputStreamReader(stream);
+        BufferedReader in = new BufferedReader(feed);
+        HTTPRequest request = new HTTPRequest(in);
+        String expectedHeaders = "HTTP/1.1 200 OK\r\nDate: bla\r\nContent-Type: text/html\r\n";
+        assertEquals(expectedHeaders + "\r\n" + "default content", new HTTPResponse(request, "bla").get());
+    }
+
+    @Test
+    void getResponseToPatchRequestForPatchContent() throws IOException {
+        String requestGetPatchContent =
+                "PATCH /patch-content.txt HTTP/1.1\r\nIf-Match: 5c36acad75b78b82be6d9cbbd6143ab7e0cc04b0\r\nline3\r\n";
+        InputStream stream = new ByteArrayInputStream(requestGetPatchContent.getBytes());
+        InputStreamReader feed = new InputStreamReader(stream);
+        BufferedReader in = new BufferedReader(feed);
+        HTTPRequest request = new HTTPRequest(in);
+        String expectedHeaders = "HTTP/1.1 204\r\nDate: bla\r\nContent-Type: text/html\r\n";
+        assertEquals(expectedHeaders + "\r\n", new HTTPResponse(request, "bla").get());
     }
 }

--- a/test/com/scottyplunkett/server/PatchContentResponseTest.java
+++ b/test/com/scottyplunkett/server/PatchContentResponseTest.java
@@ -1,0 +1,65 @@
+package com.scottyplunkett.server;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PatchContentResponseTest {
+
+    @Test
+    void getResponseToGetRequestForPatchContent() throws IOException {
+        String requestGetPatchContent = "GET /patch-content.txt HTTP/1.1\r\nline2\nline3\n";
+        InputStream stream = new ByteArrayInputStream(requestGetPatchContent.getBytes());
+        InputStreamReader feed = new InputStreamReader(stream);
+        BufferedReader in = new BufferedReader(feed);
+        HTTPRequest request = new HTTPRequest(in);
+        String expectedHeaders = "HTTP/1.1 200 OK\r\nDate: bla\r\nContent-Type: text/html\r\n";
+        assertEquals(expectedHeaders + "\r\n" + "default content", new PatchContentResponse(request, "bla").get());
+    }
+
+    @Test
+    void getResponseToPatchRequestForPatchContent() throws IOException {
+        String requestGetPatchContent =
+                "PATCH /patch-content.txt HTTP/1.1\r\nIf-Match: 5c36acad75b78b82be6d9cbbd6143ab7e0cc04b0\r\nline3\r\n";
+        InputStream stream = new ByteArrayInputStream(requestGetPatchContent.getBytes());
+        InputStreamReader feed = new InputStreamReader(stream);
+        BufferedReader in = new BufferedReader(feed);
+        HTTPRequest request = new HTTPRequest(in);
+        String expectedHeaders = "HTTP/1.1 204\r\nDate: bla\r\nContent-Type: text/html\r\n";
+        assertEquals(expectedHeaders + "\r\n", new PatchContentResponse(request, "bla").get());
+    }
+
+    @Test
+    void patchesContentWithRequestBody() throws IOException {
+        String requestPatchContent =
+                "PATCH /patch-content.txt HTTP/1.1\r\n" +
+                "If-Match: dc50a0d27dda2eee9f65644cd7e4c9cf11de8bec\r\n" +
+                "line3\r\n" +
+                "patched content";
+        InputStream stream = new ByteArrayInputStream(requestPatchContent.getBytes());
+        InputStreamReader feed = new InputStreamReader(stream);
+        BufferedReader in = new BufferedReader(feed);
+        HTTPRequest request = new HTTPRequest(in);
+        PatchContentResponse patchContentResponse = new PatchContentResponse(request, "bla");
+        Path patchContentPath = Paths.get("public/patch-content.txt");
+        PageContent pageContent = new PageContent(patchContentPath, request.getRequestLine());
+        assertEquals("patched content", pageContent.get());
+
+        String secondRequestPatchContent =
+                "PATCH /patch-content.txt HTTP/1.1\r\n" +
+                "If-Match: 5c36acad75b78b82be6d9cbbd6143ab7e0cc04b0\r\n" +
+                "line3\r\n" +
+                "default content";
+        InputStream stream2 = new ByteArrayInputStream(secondRequestPatchContent.getBytes());
+        InputStreamReader feed2 = new InputStreamReader(stream2);
+        BufferedReader in2 = new BufferedReader(feed2);
+        HTTPRequest request2 = new HTTPRequest(in2);
+        PatchContentResponse secondPatchContentResponse = new PatchContentResponse(request2, "bla");
+        PageContent pageContent2 = new PageContent(patchContentPath, request2.getRequestLine());
+        assertEquals("default content", pageContent2.get());
+    }
+}

--- a/test/com/scottyplunkett/server/RouterTest.java
+++ b/test/com/scottyplunkett/server/RouterTest.java
@@ -69,4 +69,16 @@ class RouterTest {
         Path expectedPath = Paths.get("pages/method_options.html");
         assertEquals(expectedPath, Router.route("OPTIONS /method_options2 HTTP/1.1"));
     }
+
+    @Test
+    void testRouteForGetRequestOfPatchContent() {
+        Path expectedPath = Paths.get("public/patch-content.txt");
+        assertEquals(expectedPath, Router.route("GET /patch-content.txt HTTP/1.1"));
+    }
+
+    @Test
+    void testRouteForPatchRequestOfPatchContent() {
+        Path expectedPath = Paths.get("public/patch-content.txt");
+        assertEquals(expectedPath, Router.route("PATCH /patch-content.txt HTTP/1.1"));
+    }
 }


### PR DESCRIPTION
- Creates `PatchContentResponse` object 
- Adds patch conditional logic to HTTPResponse 
- Updates routes for `/patch-content.txt` request 
- Adds Request accessor methods for Etag, Body
- Passes Patch w/ Etag CobSpec test