### PR TITLE
Renamed Content Response Classes to Handlers

### DIFF
--- a/src/com/scottyplunkett/server/CookieHandler.java
+++ b/src/com/scottyplunkett/server/CookieHandler.java
@@ -6,18 +6,18 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Collectors;
 
-class CookieContentResponse {
+class CookieHandler {
     private String cookieValue;
     private Path cookieContentPath;
     private String cookieResponseBody;
     private String cookieResponseHeaders;
     private byte[] response;
 
-    CookieContentResponse(HTTPRequest request, String date) throws IOException {
+    CookieHandler(HTTPRequest request, String date) throws IOException {
         this(request, Paths.get("pages/cookie.html"), date);
     }
 
-    CookieContentResponse(HTTPRequest request, Path path, String date) throws IOException {
+    CookieHandler(HTTPRequest request, Path path, String date) throws IOException {
         cookieContentPath = path;
         cookieValue = request.getCookie();
         cookieResponseBody = request.getRequestLine().contains("/eat_cookie") ?

--- a/src/com/scottyplunkett/server/FormHandler.java
+++ b/src/com/scottyplunkett/server/FormHandler.java
@@ -7,7 +7,7 @@ import java.nio.file.Paths;
 
 import static com.scottyplunkett.server.ByteArraysReducer.merge;
 
-public class FormContentResponse {
+public class FormHandler {
     private final Path formPath = Paths.get("pages/form.html");
     private HTTPRequest httpRequest;
     private String method;
@@ -16,7 +16,7 @@ public class FormContentResponse {
     private byte[] responseContent;
 
 
-    FormContentResponse(HTTPRequest request, String date) throws IOException {
+    FormHandler(HTTPRequest request, String date) throws IOException {
         httpRequest = request;
         method = Parser.findRequestMethod(httpRequest.getRequestLine());
         if(method.equals("POST") || method.equals("PUT")) writeToForm();

--- a/src/com/scottyplunkett/server/HTTPResponse.java
+++ b/src/com/scottyplunkett/server/HTTPResponse.java
@@ -19,17 +19,17 @@ class HTTPResponse {
         String requestedRoute = Parser.findRequestedRoute(requestLine);
         String method = Parser.findRequestMethod(requestLine);
         if(requestLine.contains("PATCH")) {
-            responseContent = new PatchContentResponse(request, date).get().getBytes();
+            responseContent = new PatchHandler(request, date).get().getBytes();
         } else if(requestLine.contains("image")) {
-            responseContent = new ImageContentResponse(requestLine, date).get();
+            responseContent = new ImageHandler(requestLine, date).get();
         } else if(requestLine.contains("cookie")) {
-            responseContent = new CookieContentResponse(request, date).get();
+            responseContent = new CookieHandler(request, date).get();
         } else if(requestLine.contains("logs")) {
-            responseContent = new LogContentResponse(request, date).get();
+            responseContent = new LogsHandler(request, date).get();
         } else if(requestLine.contains("form")) {
-            responseContent = new FormContentResponse(request, date).get();
+            responseContent = new FormHandler(request, date).get();
         } else if(requestLine.contains("partial_content")) {
-            responseContent = new PartialContentResponse(request, date).get();
+            responseContent = new PartialHandler(request, date).get();
         } else {
             if((requestedRoute.equals("/file1") ||
                requestedRoute.equals("/text-file.txt")) &&

--- a/src/com/scottyplunkett/server/ImageHandler.java
+++ b/src/com/scottyplunkett/server/ImageHandler.java
@@ -6,18 +6,18 @@ import java.nio.file.Path;
 
 import static com.scottyplunkett.server.ByteArraysReducer.merge;
 
-class ImageContentResponse {
+class ImageHandler {
     private Path imagePath;
     private String type;
     private byte[] imageData;
     private byte[] imageHeaders;
     private byte[] response;
 
-    ImageContentResponse(String requestLine) throws IOException {
+    ImageHandler(String requestLine) throws IOException {
         this(requestLine, Date.getDate());
     }
 
-    ImageContentResponse(String requestLine, String date) throws IOException {
+    ImageHandler(String requestLine, String date) throws IOException {
         imagePath = Router.route(requestLine);
         type = Files.probeContentType(imagePath);
         imageData = Files.readAllBytes(imagePath);

--- a/src/com/scottyplunkett/server/LogsHandler.java
+++ b/src/com/scottyplunkett/server/LogsHandler.java
@@ -6,7 +6,7 @@ import java.nio.file.Paths;
 
 import static com.scottyplunkett.server.ByteArraysReducer.merge;
 
-class LogContentResponse {
+class LogsHandler {
     private final String authHeader = "WWW-Authenticate: Basic realm=\"Logs\"";
     private HTTPRequest httpRequest;
     private boolean authorized;
@@ -14,7 +14,7 @@ class LogContentResponse {
     private byte[] body;
     private byte[] responseContent;
 
-    LogContentResponse(HTTPRequest request, String date) throws IOException {
+    LogsHandler(HTTPRequest request, String date) throws IOException {
         httpRequest = request;
         if(isAuthorized()) {
             head = (new HTTPResponseHeaders("200 OK", "text/html", date).get() + "\r\n").getBytes();

--- a/src/com/scottyplunkett/server/PartialHandler.java
+++ b/src/com/scottyplunkett/server/PartialHandler.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 
 import static com.scottyplunkett.server.ByteArraysReducer.merge;
 
-class PartialContentResponse {
+class PartialHandler {
     private final Path partialContentPath = Paths.get("public/partial_content.txt");
 
     private HTTPRequest httpRequest;
@@ -21,7 +21,7 @@ class PartialContentResponse {
     private byte[] body;
     private byte[] responseContent;
 
-    PartialContentResponse(HTTPRequest request, String date) throws IOException {
+    PartialHandler(HTTPRequest request, String date) throws IOException {
         httpRequest = request;
         fileContents = Files.readAllBytes(partialContentPath);
         totalBytes = fileContents.length;

--- a/src/com/scottyplunkett/server/PatchHandler.java
+++ b/src/com/scottyplunkett/server/PatchHandler.java
@@ -5,7 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-class PatchContentResponse {
+class PatchHandler {
     private String responseContent;
     private String headers;
     private String body;
@@ -16,7 +16,7 @@ class PatchContentResponse {
     private final byte[] patchBytes = "patched content".getBytes();
     private final Path path = Paths.get("public/patch-content.txt");
 
-    PatchContentResponse(HTTPRequest request, String date) throws IOException {
+    PatchHandler(HTTPRequest request, String date) throws IOException {
         String requestLine = request.getRequestLine();
         String requestMethod = requestLine.split("\\s")[0];
         if("PATCH".equals(requestMethod)) {

--- a/test/com/scottyplunkett/server/CookieHandlerTest.java
+++ b/test/com/scottyplunkett/server/CookieHandlerTest.java
@@ -9,7 +9,7 @@ import java.io.InputStream;
 import static com.scottyplunkett.server.ByteArraysReducer.merge;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-class CookieContentResponseTest {
+class CookieHandlerTest {
 
     @Test
     void get() throws IOException {
@@ -20,7 +20,7 @@ class CookieContentResponseTest {
         HTTPResponseHeaders headersBeforeAppend = new HTTPResponseHeaders("200 OK", "text/html", "bla");
         byte[] head = (headersBeforeAppend.get() + "Set-Cookie: chocolate\r\n" + "\r\n").getBytes();
         byte[] expectedResponse = merge(body, head);
-        assertArrayEquals(expectedResponse, new CookieContentResponse(request, "bla").get());
+        assertArrayEquals(expectedResponse, new CookieHandler(request, "bla").get());
     }
 
     @Test
@@ -32,6 +32,6 @@ class CookieContentResponseTest {
         HTTPResponseHeaders headersBeforeAppend = new HTTPResponseHeaders("200 OK", "text/html", "bla");
         byte[] head = (headersBeforeAppend.get() + "Set-Cookie: chocolate\r\n" + "\r\n").getBytes();
         byte[] expectedResponse = merge(body, head);
-        assertArrayEquals(expectedResponse, new CookieContentResponse(request, "bla").get());
+        assertArrayEquals(expectedResponse, new CookieHandler(request, "bla").get());
     }
 }

--- a/test/com/scottyplunkett/server/FormHandlerTest.java
+++ b/test/com/scottyplunkett/server/FormHandlerTest.java
@@ -9,7 +9,7 @@ import java.io.InputStream;
 import static com.scottyplunkett.server.ByteArraysReducer.merge;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-class FormContentResponseTest {
+class FormHandlerTest {
     @Test
     void getPost() throws IOException {
         String requestPostToForm = "POST /form HTTP/1.1\r\nContent-Length: 11\r\nline3\r\n\r\ndata=fatcat";
@@ -18,7 +18,7 @@ class FormContentResponseTest {
         byte[] head = (new HTTPResponseHeaders("200 OK", "text/html", "bla").get() + "\r\n").getBytes();
         byte[] body = "<h1>data=fatcat</h1>".getBytes();
         byte[] expectedResponse = merge(body, head);
-        assertArrayEquals(expectedResponse, new FormContentResponse(request, "bla").get());
+        assertArrayEquals(expectedResponse, new FormHandler(request, "bla").get());
     }
 
     @Test
@@ -29,7 +29,7 @@ class FormContentResponseTest {
         byte[] head = (new HTTPResponseHeaders("200 OK", "text/html", "bla").get() + "\r\n").getBytes();
         byte[] body = "<h1>data=healthcliff</h1>".getBytes();
         byte[] expectedResponse = merge(body, head);
-        assertArrayEquals(expectedResponse, new FormContentResponse(request, "bla").get());
+        assertArrayEquals(expectedResponse, new FormHandler(request, "bla").get());
     }
 
     @Test
@@ -40,7 +40,7 @@ class FormContentResponseTest {
         byte[] head = (new HTTPResponseHeaders("200 OK", "text/html", "bla").get() + "\r\n").getBytes();
         byte[] body = "".getBytes();
         byte[] expectedResponse = merge(body, head);
-        assertArrayEquals(expectedResponse, new FormContentResponse(request, "bla").get());
+        assertArrayEquals(expectedResponse, new FormHandler(request, "bla").get());
     }
 
 }

--- a/test/com/scottyplunkett/server/ImageHandlerTest.java
+++ b/test/com/scottyplunkett/server/ImageHandlerTest.java
@@ -9,14 +9,14 @@ import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-class ImageContentResponseTest {
+class ImageHandlerTest {
 
     @Test
     void getJPEG() throws IOException {
         Path jpegPath = Paths.get("public/image.jpeg");
         byte[] expectedImage = Files.readAllBytes(jpegPath);
         String requestLine = "GET /image.jpeg HTTP/1.1";
-        assertArrayEquals(expectedImage, new ImageContentResponse(requestLine).getImageData());
+        assertArrayEquals(expectedImage, new ImageHandler(requestLine).getImageData());
     }
 
     @Test
@@ -24,7 +24,7 @@ class ImageContentResponseTest {
         Path gifPath = Paths.get("public/image.gif");
         byte[] expectedImage = Files.readAllBytes(gifPath);
         String requestLine = "GET /image.gif HTTP/1.1";
-        assertArrayEquals(expectedImage, new ImageContentResponse(requestLine).getImageData());
+        assertArrayEquals(expectedImage, new ImageHandler(requestLine).getImageData());
     }
 
     @Test
@@ -32,6 +32,6 @@ class ImageContentResponseTest {
         Path pngPath = Paths.get("public/image.png");
         byte[] expectedImage = Files.readAllBytes(pngPath);
         String requestLine = "GET /image.png HTTP/1.1";
-        assertArrayEquals(expectedImage, new ImageContentResponse(requestLine).getImageData());
+        assertArrayEquals(expectedImage, new ImageHandler(requestLine).getImageData());
     }
 }

--- a/test/com/scottyplunkett/server/LogsHandlerTest.java
+++ b/test/com/scottyplunkett/server/LogsHandlerTest.java
@@ -11,7 +11,7 @@ import java.nio.file.Paths;
 import static com.scottyplunkett.server.ByteArraysReducer.merge;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-class LogContentResponseTest {
+class LogsHandlerTest {
     @Test
     void getLogsReturns401WithoutAuth() throws IOException {
         String requestLogs = "GET /logs HTTP/1.1\r\nline 4\r\nline3\r\n";
@@ -21,7 +21,7 @@ class LogContentResponseTest {
                                                "WWW-Authenticate: Basic realm=\"Logs\"\r\n\r\n").getBytes();
         byte[] body = "401 Unauthorized... Probably Above Your Paygrade.".getBytes();
         byte[] expectedResponse = merge(body, head);
-        assertArrayEquals(expectedResponse, new LogContentResponse(request, "bla").get());
+        assertArrayEquals(expectedResponse, new LogsHandler(request, "bla").get());
     }
 
     @Test
@@ -32,6 +32,6 @@ class LogContentResponseTest {
         byte[] head = (new HTTPResponseHeaders("200 OK", "text/html", "bla").get() + "\r\n").getBytes();
         byte[] body = Files.readAllBytes(Paths.get("logs/logs.html"));
         byte[] expectedResponse = merge(body, head);
-        assertArrayEquals(expectedResponse, new LogContentResponse(request, "bla").get());
+        assertArrayEquals(expectedResponse, new LogsHandler(request, "bla").get());
     }
 }

--- a/test/com/scottyplunkett/server/PartialHandlerTest.java
+++ b/test/com/scottyplunkett/server/PartialHandlerTest.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import static com.scottyplunkett.server.ByteArraysReducer.merge;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-class PartialContentResponseTest {
+class PartialHandlerTest {
     @Test
     void getRangeOfPartialContent() throws IOException {
         String requestPartialContent = "GET /partial_content.txt HTTP/1.1\r\nRange: bytes=0-4\r\nline3\r\n\r\n";
@@ -23,7 +23,7 @@ class PartialContentResponseTest {
         byte[] partialContent = "This is a file that contains text to read part of in order to fulfill a 206.\n".getBytes();
         byte[] body = Arrays.copyOfRange(partialContent,0,5);
         byte[] expectedResponse = merge(body, head);
-        assertArrayEquals(expectedResponse, new PartialContentResponse(request, "bla").get());
+        assertArrayEquals(expectedResponse, new PartialHandler(request, "bla").get());
     }
 
     @Test
@@ -38,7 +38,7 @@ class PartialContentResponseTest {
         byte[] partialContent = "This is a file that contains text to read part of in order to fulfill a 206.\n".getBytes();
         byte[] body = Arrays.copyOfRange(partialContent,71,77);
         byte[] expectedResponse = merge(body, head);
-        assertArrayEquals(expectedResponse, new PartialContentResponse(request, "bla").get());
+        assertArrayEquals(expectedResponse, new PartialHandler(request, "bla").get());
     }
 
 }

--- a/test/com/scottyplunkett/server/PatchHandlerTest.java
+++ b/test/com/scottyplunkett/server/PatchHandlerTest.java
@@ -8,7 +8,7 @@ import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class PatchContentResponseTest {
+class PatchHandlerTest {
 
     @Test
     void getResponseToGetRequestForPatchContent() throws IOException {
@@ -16,7 +16,7 @@ class PatchContentResponseTest {
         InputStream in = new ByteArrayInputStream(requestGetPatchContent.getBytes());
         HTTPRequest request = new HTTPRequest(in);
         String expectedHeaders = "HTTP/1.1 200 OK\r\nDate: bla\r\nContent-Type: text/plain\r\n";
-        assertEquals(expectedHeaders + "\r\n" + "default content", new PatchContentResponse(request, "bla").get());
+        assertEquals(expectedHeaders + "\r\n" + "default content", new PatchHandler(request, "bla").get());
     }
 
     @Test
@@ -26,7 +26,7 @@ class PatchContentResponseTest {
         InputStream in = new ByteArrayInputStream(requestGetPatchContent.getBytes());
         HTTPRequest request = new HTTPRequest(in);
         String expectedHeaders = "HTTP/1.1 204\r\nDate: bla\r\nContent-Type: text/plain\r\n";
-        assertEquals(expectedHeaders + "\r\n", new PatchContentResponse(request, "bla").get());
+        assertEquals(expectedHeaders + "\r\n", new PatchHandler(request, "bla").get());
     }
 
     @Test
@@ -38,7 +38,7 @@ class PatchContentResponseTest {
                 "patched content";
         InputStream in = new ByteArrayInputStream(requestPatchContent.getBytes());
         HTTPRequest request = new HTTPRequest(in);
-        PatchContentResponse patchContentResponse = new PatchContentResponse(request, "bla");
+        PatchHandler patchHandler = new PatchHandler(request, "bla");
         Path patchContentPath = Paths.get("public/patch-content.txt");
         PageContent pageContent = new PageContent(patchContentPath, request.getRequestLine());
         assertEquals("patched content", pageContent.get());
@@ -50,7 +50,7 @@ class PatchContentResponseTest {
                 "default content";
         InputStream in2 = new ByteArrayInputStream(secondRequestPatchContent.getBytes());
         HTTPRequest request2 = new HTTPRequest(in2);
-        PatchContentResponse secondPatchContentResponse = new PatchContentResponse(request2, "bla");
+        PatchHandler secondPatchHandler = new PatchHandler(request2, "bla");
         PageContent pageContent2 = new PageContent(patchContentPath, request2.getRequestLine());
         assertEquals("default content", pageContent2.get());
     }


### PR DESCRIPTION
**Renames (classes and associated tests):**
- CookieContentResponse -> _CookieHandler_
- FormContenttResponse -> _FormHandler_
- ImageContentResponse -> _ImageHandler_
- LogContentResponse -> _LogsHandler_
- PartialContentResponse -> _PartialHandler_
- PatchContentResponse -> _PatchHandler_